### PR TITLE
Add winnow parser PoC for mtree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +99,12 @@ dependencies = [
  "unicode-width",
  "yansi",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cc"
@@ -80,12 +135,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -109,10 +180,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "memchr"
@@ -143,6 +237,7 @@ dependencies = [
  "ariadne",
  "chumsky",
  "flate2",
+ "winnow",
 ]
 
 [[package]]
@@ -190,6 +285,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,7 +333,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -237,6 +345,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -252,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,11 +383,44 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -272,15 +429,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -290,9 +453,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -308,9 +483,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -320,15 +507,40 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "is-terminal",
+ "memchr",
+ "terminal_size",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ anyhow = "1"
 ariadne = "0.4"
 chumsky = "1.0.0-alpha.7"
 flate2 = "1"
+winnow = { version = "0.6.20", features = ["debug"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,22 @@ use std::{
 
 use anyhow::Result;
 use ariadne::{Color, Label, Report, ReportKind, Source};
-use chumsky::{prelude::*, text::ascii, Parser};
+use chumsky::{
+    prelude::*,
+    text::{ascii, newline},
+    Parser,
+};
 use flate2::read::GzDecoder;
-use text::newline;
+
+use winnow::{
+    ascii::{alpha1, alphanumeric1, line_ending, space0, space1},
+    combinator::{alt, delimited, preceded, repeat, separated_pair, terminated},
+    token::take_till,
+    PResult, Parser as WinnowParser,
+};
 
 /// Each line represents a line in a .MTREE file
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Statement<'a> {
     /// The initial `#mtree` line at the top of the file
     Init,
@@ -27,7 +37,7 @@ enum Statement<'a> {
 }
 
 /// This type is used in `/set` and `/unset` commands to modify the currently active defaults.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum DefaultProperty<'a> {
     Uid(usize),
     Gid(usize),
@@ -36,7 +46,7 @@ enum DefaultProperty<'a> {
 }
 
 /// This type is used in a [Path] line and defines some available properties for that path.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Property<'a> {
     Mode(&'a str),
     Type(PathType),
@@ -47,54 +57,15 @@ enum Property<'a> {
 }
 
 // What kind of type is a path.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PathType {
     Dir,
     File,
     Link,
 }
 
-fn main() -> Result<()> {
-    let compressed = false;
-    // Either read the compressed or already uncompressed .MTREE file at the root of this
-    // repo and return the contents.
-    let content = if compressed {
-        let gz_content = fs::read(".MTREE")?;
-        let mut decoder = GzDecoder::new(gz_content.as_slice());
-
-        let mut content = String::new();
-        decoder.read_to_string(&mut content).unwrap();
-        content
-    } else {
-        String::from_utf8_lossy(&fs::read(".MTREE.extracted")?).to_string()
-    };
-
-    //println!("{}", content);
-
-    // Parse the file
-    let (ast, errs) = parser().parse(content.trim()).into_output_errors();
-
-    // Print out the AST
-    println!("{:#?}", ast);
-
-    // Print out any errors.
-    errs.into_iter().for_each(|e| {
-        Report::build(ReportKind::Error, (), e.span().start)
-            .with_message(e.to_string())
-            .with_label(
-                Label::new(e.span().into_range())
-                    .with_message(e.reason().to_string())
-                    .with_color(Color::Red),
-            )
-            .finish()
-            .print(Source::from(&content))
-            .unwrap()
-    });
-
-    Ok(())
-}
-
-fn parser<'a>() -> impl Parser<'a, &'a str, Vec<Statement<'a>>, extra::Err<Rich<'a, char>>> {
+fn parser_chumsky<'a>() -> impl Parser<'a, &'a str, Vec<Statement<'a>>, extra::Err<Rich<'a, char>>>
+{
     use Statement::*;
 
     // Parser for the very first line of the `.MTREE` file
@@ -203,4 +174,173 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Vec<Statement<'a>>, extra::Err<Rich<
         .map(|(path, properties)| Path { path, properties });
 
     recursive(|_| choice((mtree, set, unset, path)).repeated().collect())
+}
+
+/// Parses a single value until a space or newline is encountered.
+fn value<'s>(i: &mut &'s str) -> PResult<&'s str> {
+    terminated(
+        take_till(0.., |c| c == ' ' || c == '\n'),
+        alt((space1, line_ending)),
+    )
+    .parse_next(i)
+}
+
+/// Parses a single value until a space or newline is encountered
+///
+/// This parser also consumes any trailing whitespace or newlines.
+fn value_terminated<'s>(i: &mut &'s str) -> PResult<&'s str> {
+    (value, alt((space0, line_ending)))
+        .parse_next(i)
+        .map(|(v, _)| v)
+}
+
+/// Parses the initial `#mtree` line at the top of the file.
+fn init<'s>(i: &mut &'s str) -> PResult<Statement<'s>> {
+    terminated("#mtree", line_ending)
+        .parse_next(i)
+        .map(|_| Statement::Init)
+}
+
+/// Parses a single default property.
+fn default_property<'s>(i: &mut &'s str) -> PResult<DefaultProperty<'s>> {
+    separated_pair(alpha1, "=", value)
+        .verify_map(|(k, v)| match k {
+            "uid" => Some(DefaultProperty::Uid(v.parse().ok()?)),
+            "gid" => Some(DefaultProperty::Gid(v.parse().ok()?)),
+            "type" => match v {
+                "dir" => Some(DefaultProperty::Type(PathType::Dir)),
+                "file" => Some(DefaultProperty::Type(PathType::File)),
+                "link" => Some(DefaultProperty::Type(PathType::Link)),
+                _ => panic!("unknown type: {v}"),
+            },
+            "mode" => Some(DefaultProperty::Mode(v)),
+            _ => panic!("unknown property: {k}"),
+        })
+        .parse_next(i)
+}
+
+/// Parses a list of default properties.
+fn default_properties<'s>(i: &mut &'s str) -> PResult<Vec<DefaultProperty<'s>>> {
+    repeat(0.., default_property).parse_next(i)
+}
+
+/// Parses a `/set` command followed by some properties.
+fn set<'s>(i: &mut &'s str) -> PResult<Statement<'s>> {
+    delimited(("/set", space0), default_properties, line_ending)
+        .parse_next(i)
+        .map(Statement::Set)
+}
+
+/// Parses a `/unset` command followed by some properties.
+fn unset<'s>(i: &mut &'s str) -> PResult<Statement<'s>> {
+    delimited(("/unset", space0), default_properties, line_ending)
+        .parse_next(i)
+        .map(Statement::Unset)
+}
+
+/// Parses a single property.
+fn property<'s>(i: &mut &'s str) -> PResult<Property<'s>> {
+    separated_pair(alphanumeric1, "=", value)
+        .verify_map(|(k, v)| match k {
+            "type" => match v {
+                "dir" => Some(Property::Type(PathType::Dir)),
+                "file" => Some(Property::Type(PathType::File)),
+                "link" => Some(Property::Type(PathType::Link)),
+                _ => panic!("unknown type: {v}"),
+            },
+            "mode" => Some(Property::Mode(v)),
+            "size" => Some(Property::Size(v.parse().ok()?)),
+            "link" => Some(Property::Link(v)),
+            "sha256digest" => Some(Property::Sha256Digest(v)),
+            "time" => Some(Property::Time(v.split_once(".")?.0.parse().ok()?)),
+            _ => panic!("unknown property: {k}"),
+        })
+        .parse_next(i)
+}
+
+/// Parses a list of properties.
+fn properties<'s>(i: &mut &'s str) -> PResult<Vec<Property<'s>>> {
+    repeat(0.., property).parse_next(i)
+}
+
+/// Parses a path line followed by some properties.
+fn path<'s>(i: &mut &'s str) -> PResult<Statement<'s>> {
+    let path = preceded(".", value).parse_next(i)?;
+    let properties = delimited(' ', properties, line_ending).parse_next(i)?;
+    Ok(Statement::Path { path, properties })
+}
+
+/// Parses the next statement in the file.
+fn statement<'s>(i: &mut &'s str) -> PResult<Statement<'s>> {
+    let statement_type: &str = alt((
+        (".", value).take(),
+        "/set ",
+        "/unset ",
+        terminated("#mtree", line_ending),
+    ))
+    .parse_next(i)?;
+
+    let statement = match statement_type {
+        "/set " => Statement::Set(default_properties(i)?),
+        "/unset " => Statement::Unset(default_properties(i)?),
+        "#mtree" => Statement::Init,
+        path => Statement::Path {
+            path,
+            properties: properties(i)?,
+        },
+    };
+
+    Ok(statement)
+}
+
+/// Parses the entire .MTREE file.
+fn parser<'s>(i: &mut &'s str) -> PResult<Vec<Statement<'s>>> {
+    repeat(0.., statement).parse_next(i)
+}
+
+fn main() -> Result<()> {
+    let compressed = false;
+    // Either read the compressed or already uncompressed .MTREE file at the root of this
+    // repo and return the contents.
+    let content = if compressed {
+        let gz_content = fs::read(".MTREE")?;
+        let mut decoder = GzDecoder::new(gz_content.as_slice());
+
+        let mut content = String::new();
+        decoder.read_to_string(&mut content).unwrap();
+        content
+    } else {
+        String::from_utf8_lossy(&fs::read(".MTREE.extracted")?).to_string()
+    };
+
+    match parser.parse_next(&mut content.as_str()) {
+        Ok(ast) => {
+            println!("{:#?}", ast);
+        }
+        Err(e) => {
+            eprintln!("{e}");
+        }
+    }
+
+    // Parse the file
+    let (_ast, errs) = parser_chumsky().parse(content.trim()).into_output_errors();
+
+    // Print out the AST
+    // println!("{:#?}", ast);
+
+    // Print out any errors.
+    errs.into_iter().for_each(|e| {
+        Report::build(ReportKind::Error, (), e.span().start)
+            .with_message(e.to_string())
+            .with_label(
+                Label::new(e.span().into_range())
+                    .with_message(e.reason().to_string())
+                    .with_color(Color::Red),
+            )
+            .finish()
+            .print(Source::from(&content))
+            .unwrap()
+    });
+
+    Ok(())
 }


### PR DESCRIPTION
This PR adds the parser for mtree files using [winnow](https://docs.rs/winnow) for comparison purposes.

Here are some things to be figured out:

- [ ] Error reporting (similar to `ariadne`, see the [docs](https://docs.rs/winnow/latest/winnow/_tutorial/chapter_7/index.html))
- [ ] Avoiding `panic!`s
